### PR TITLE
Install buildah for building container images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,5 +16,14 @@ RUN set -ex \
   && mv /tmp/kubectl /usr/local/bin/kubectl \
   && kubectl version --client
 
+# Install buildah and related tooling for building container images.
+RUN set -ex \
+  && apt-get update \
+  && apt-get install -y --no-install-recommends \
+    buildah \
+    fuse-overlayfs \
+    uidmap \
+  && rm -rf /var/lib/apt/lists/*
+
 # Switch back to the regular user.
 USER tfc-agent


### PR DESCRIPTION
Some hoops will need to be jumped through on the K8s side to get this working. But in theory, it should work.

See https://developers.redhat.com/blog/2019/08/14/best-practices-for-running-buildah-in-a-container