### PR TITLE
Install gke-gcloud-auth-plugin

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,14 @@ FROM hashicorp/tfc-agent:1.28.3
 USER root
 
 RUN set -ex \
+  && apt-get update \
+  && apt-get install -y --no-install-recommends \
+    curl \
+    gnupg \
+    unzip \
+  && rm -rf /var/lib/apt/lists/*
+
+RUN set -ex \
   && curl -fsSL --compressed -o /tmp/awscliv2.zip 'https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip' \
   && unzip -q /tmp/awscliv2.zip -d /tmp \
   && /tmp/aws/install \
@@ -15,6 +23,17 @@ RUN set -ex \
   && chmod +x /tmp/kubectl \
   && mv /tmp/kubectl /usr/local/bin/kubectl \
   && kubectl version --client
+
+# Install GKE auth plugin for kubectl to authenticate with GKE clusters.
+# See https://docs.cloud.google.com/kubernetes-engine/docs/how-to/cluster-access-for-kubectl#install_plugin.
+RUN set -ex \
+  && curl -fsSL --compressed https://packages.cloud.google.com/apt/doc/apt-key.gpg | gpg --dearmor -o /usr/share/keyrings/cloud.google.gpg \
+  && echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list \
+  && apt-get update \
+  && apt-get install -y --no-install-recommends \
+    google-cloud-sdk-gke-gcloud-auth-plugin \
+  && rm -rf /var/lib/apt/lists/* \
+  && gke-gcloud-auth-plugin --version
 
 # Install buildah and related tooling for building container images.
 RUN set -ex \


### PR DESCRIPTION
This is needed to connect to GKE via kubectl, which is useful to avoid auth token timeouts. That's the same reason we install the AWS CLI.