### PR TITLE
Install crun

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -40,6 +40,7 @@ RUN set -ex \
   && apt-get update \
   && apt-get install -y --no-install-recommends \
     buildah \
+    crun \
     fuse-overlayfs \
     uidmap \
   && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
Adds crun (runtime) so that RUN Dockerfile commands work when building with buildah in infra.

In my lambda PR (https://github.com/hightouchio/infra/pull/5100/) I'm getting the error:

```
exec: no command
```

during my buildah build at the first RUN command. This Dockerfile succeeds with docker (but hard to test buildah on Mac). This means our buildah is missing an oci runtime. Example issue: https://github.com/containers/buildah/issues/1754

From my investigation:
- on Debian, crun and runc are Recommends of buildah but not hard Depends
- `--no-install-recommends` causes it to not be installed

We didn't run into this with image resizer because that Dockerfile doesn't have RUN commands.